### PR TITLE
add(font): Poppins

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,9 +19,16 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-poppins);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-geist-mono);
 }
 
 * {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Poppins } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const poppins = Poppins({
+  variable: "--font-poppins",
   subsets: ["latin"],
+  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
 });
 
 const geistMono = Geist_Mono({
@@ -24,7 +25,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+      <body className={`${poppins.variable} ${geistMono.variable}`}>
         {children}
       </body>
     </html>


### PR DESCRIPTION
# Imported [Poppins](https://fonts.google.com/specimen/Poppins) from Google Fonts 

> Closes #2

In alignment with our design system (see below): 

> [!IMPORTANT]
> The colors in the picture may not be up-to-date. 
> FosterSource rebranded to Be The Source, and in the process updated some of their colors. The picture below uses their old color schemes and may have changed. 
> If you need color references, please refer to the [Figma](https://www.figma.com/design/ladu23p6wZ0r9y1wS1cSIT/Foster-Source) for the most updated content or contact @kohrachel or our designer Vince :) 
> (If link is broken, contact @kohrachel)

<img width="749" height="322" alt="image" src="https://github.com/user-attachments/assets/97301dcb-69ac-41c3-b1ca-451e13cb4d48" />

## Preview: 

<img width="2730" height="1453" alt="image" src="https://github.com/user-attachments/assets/bdfd8e8d-7077-4051-82b8-432c29000baf" />

Here is a GIF preview: 

![Clipboard-20250927-225859-930](https://github.com/user-attachments/assets/94e4c419-fde1-4f76-877c-9698d3ac09e8)

