### PR TITLE
add(GitHub Actions): Setup lint and format on push

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -1,0 +1,32 @@
+name: Lint and Format
+
+on:
+  push:
+    branches: ["*"] # Runs on all branches
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run linting
+        run: bun run lint
+
+      - name: Check formatting
+        run: bun run format:check
+
+      - name: Run full check
+        run: bun run check


### PR DESCRIPTION
# Automatically lints and formats code

On pushing to a branch, code will be automatically linted and formatted with: 

```zsh
# eslint
bun run lint

# prettier --check .
bun run format:check

# bun run lint && bun run format:check
bun run check 
```

This also runs when trying to merge a pull request into main. 

Closes #4 