### PR TITLE
add(PR template): PR Default Body Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ PR Title naming format:
 Types:
 add - Something new (e.g. a new feature)
 fix - A bug fix
-docs - Updating documentation}
+docs - Updating documentation
 
 Scope:
 The thing you changed (e.g. Admin Dashboard, Auto Emails)
@@ -14,21 +14,21 @@ Example title:
 add(font): Poppins
 -->
 
-## [brief summary here]
+# [brief summary here]
 
 <!--
 Explain what you did!
 If I need to do something in order to use this feature, put it here
 -->
 
-## Visual Overview (if frontend/UI)
+# Visual Overview (if frontend/UI)
 
 <!-- Include a screenshot, video, or GIF of the UI change -->
 
-## List of changes (if backend)
+# List of changes (if backend)
 
 <!-- Mention endpoints/tables/etc changed + before and after -->
 
-## Additional Resources/Links
+# (optional) Additional Resources/Links
 
-<!-- Docs, StackOverflow, yadda yadda yadda -->
+<!-- Docs, StackOverflow, yadda yadda yadda. Omit if uneccessary -->


### PR DESCRIPTION
# PR template auto-populates with some structure

## Assists in following PR naming format, e.g. 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6b68ece9-6cb9-4b3d-bba5-4191c916e398" />

List of PRs currently in the codebase (Oct 12, 2025). 

# Visual Overview

<img width="400" alt="image" src="https://github.com/user-attachments/assets/0c6f684d-321a-4883-b409-5a6ff28e96d2" />

## Example: This PR! 

<img width="2839" height="2474" alt="image" src="https://github.com/user-attachments/assets/4b6c5217-db0c-44a6-bd78-b3a0a5814baf" />

# Additional Resources/Links

See GitHub [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) for more info. 